### PR TITLE
Add FLAG_IMMUTABLE to pending intent

### DIFF
--- a/src/android/BringToFront.java
+++ b/src/android/BringToFront.java
@@ -21,7 +21,10 @@ public class BringToFront extends CordovaPlugin {
       Log.d("BringToFront", "I see you");
       Intent notificationIntent = new Intent(cordova.getActivity(), cordova.getActivity().getClass());
       notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-      PendingIntent pendingIntent = PendingIntent.getActivity(cordova.getActivity(), 0, notificationIntent, 0);
+      
+      int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_IMMUTABLE : 0;
+      PendingIntent pendingIntent = PendingIntent.getActivity(cordova.getActivity(), 0, notificationIntent, flags);
+      
       try 
       {
         pendingIntent.send();


### PR DESCRIPTION
Starting from API 31, pending intents are required to explicitly specify mutability on creation.

https://developer.android.com/reference/android/app/PendingIntent#FLAG_MUTABLE